### PR TITLE
Update nodejs version

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,3 @@
 [tools]
-node = '22'
-"npm:npm" = "11.6.2"
+node = '24'
 pnpm = '10.20.0'

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cli"
   ],
   "author": "Caido Labs Inc.",
+  "repository": "https://github.com/caido-community/dev",
   "license": "MIT",
   "engines": {
     "node": ">=20",


### PR DESCRIPTION
Update nodejs to 24 in mise. This also update npm, which is needed to allow OIDC auth on npm publish.
